### PR TITLE
Fixing a bug on the panel title colors

### DIFF
--- a/themes/Taarú-dark-theme.json
+++ b/themes/Taarú-dark-theme.json
@@ -148,7 +148,7 @@
 		"panel.border": "#1e272e",
 		"panelTitle.activeBorder": "#1e272e",
 		"panelTitle.activeForeground": "#41E296",
-		"panelTitle.inactiveForeground": "#1e272e80",
+		"panelTitle.inactiveForeground": "#6C739A",
 		"statusBar.background": "#1e272e",
 		"statusBar.foreground": "#41E296",
 		"statusBar.border": "#08403F",


### PR DESCRIPTION
![bug#1-taaru](https://user-images.githubusercontent.com/46305144/99784724-25e46f00-2b14-11eb-8e7f-18e1b64efe78.png)

The colors on the *panel title* section were not showing properly for the Taaru-Dark theme. I just added the same color as the one you used for the sidebar.

![debug#1-taaru](https://user-images.githubusercontent.com/46305144/99785245-d3578280-2b14-11eb-8e35-baab66250f0d.png)

I also wanted to add a `.gitignore` file but forgot to do it. Maybe next time.  
Happy coding 😄